### PR TITLE
Python sürüm numarasını kaldırma

### DIFF
--- a/algoritmalar/gokhan-gurbetoglu/merhaba-dunya.py
+++ b/algoritmalar/gokhan-gurbetoglu/merhaba-dunya.py
@@ -1,6 +1,6 @@
 # Gökhan Gurbetoğlu
 # GitHub: https://github.com/ggurbet
 # Twitter: https://twitter.com/ggurbet
-# Programlama Dili: Python 3
+# Programlama Dili: Python
 
 print("Merhaba Dünya!")


### PR DESCRIPTION
Python için artık sürüm belirtmeye gerek yok. Bu yüzden küçük bir
değişiklikle 3 sürümü olduğu bilgisini sildim.